### PR TITLE
Add #include to glossary

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ When we hit bottlenecks in JS/Node.js scripts that can be solved by high concurr
 - [Howard Hinnants blog](https://howardhinnant.github.io)
 - [The overhead of abstraction in C/C++ vs. Python/Ruby](http://blog.reverberate.org/2014/10/the-overhead-of-abstraction-in-cc-vs.html)
 - [Competitive Programmer's Handbook](https://cses.fi/book.html)
+- [Great runthrough of thread behaviour in Node, and how to properly use UV_THREADPOOL_SIZE with some examples](https://www.future-processing.pl/blog/on-problems-with-threads-in-node-js/)
 
 Find existing real-world code:
 

--- a/glossary.md
+++ b/glossary.md
@@ -59,6 +59,14 @@ Used to describe when code is organized such that all of the source code is in t
  - Not cpp files need to be compiled
  - To use the library, no library needs to be linked (just `#include <the header>` is enough
 
+#### `#include`
+
+Using `#include` at the beginning of a file is very similar to "importing". Including a header allows you to utilize the code defined in the included header file. Literally speaking, [the compiler will "replace" the #include line with the actual contents of the file you're including when it compiles the file.](http://www.cplusplus.com/forum/articles/10627/).
+
+There are [a couple ways](https://stackoverflow.com/questions/21593/what-is-the-difference-between-include-filename-and-include-filename/21594#21594) to include headers:
+- Using carrots, ex: `<nan.h>` --> look for header in global
+- Using quotes, ex: `"hello.hpp"` --> look for header in location relative to this file
+
 #### performant
 
 A very dubious word, usually meant to refer to a program that performs well enough by some measure of enough. Prefer describing a program as either having acceptable [performance](#performance) or acceptable [efficiency](#efficiency).


### PR DESCRIPTION
Per https://github.com/mapbox/node-cpp-skel/pull/44#discussion_r122052588, add docs about what `#include` is and how to use it.

cc @springmeyer @mapsam 